### PR TITLE
Bugfix: fixed a issue where the category node for products was empty

### DIFF
--- a/src/Model/Write/Products/CollectionDecorator/CategoryReference.php
+++ b/src/Model/Write/Products/CollectionDecorator/CategoryReference.php
@@ -16,10 +16,11 @@ class CategoryReference extends AbstractDecorator
      */
     public function decorate(Collection $collection)
     {
+        $tableName = sprintf('%s_store%d', AbstractAction::MAIN_INDEX_TABLE, $collection->getStoreId());
+
         $query = $this->getConnection()
             ->select()
-            ->from($this->getTableName(AbstractAction::MAIN_INDEX_TABLE), ['category_id', 'product_id'])
-            ->where('store_id = ?', $collection->getStoreId())
+            ->from($this->getTableName($tableName), ['category_id', 'product_id'])
             ->where('product_id IN(' . implode(',', $collection->getIds()) . ')')
             ->query();
 


### PR DESCRIPTION
Magento 2.2.5 introduced parallel indexers which caused the catalog-product
relationship to be saved to different table for each storeview. The table name
used in the query to retrieve those nodes had to be changed so it would pick the
appropiate table for the collection.

The table name is now generated by using the store id of the current collection.